### PR TITLE
Add head URL for --HEAD

### DIFF
--- a/build/oh-my-posh.txt
+++ b/build/oh-my-posh.txt
@@ -2,6 +2,7 @@ class OhMyPosh < Formula
   desc "Prompt theme engine for any shell"
   homepage "https://ohmyposh.dev"
   url "https://github.com/JanDeDobbeleer/oh-my-posh/archive/v<VERSION>.tar.gz"
+  head "https://github.com/JanDeDobbeleer/oh-my-posh.git", branch: "main"
   sha256 "<SHA256>"
   license "GPL-3.0-only"
   version "<VERSION>"


### PR DESCRIPTION
With this small change, it would be possible to install the HEAD version of oh-my-posh.
Usage:
`brew install --HEAD oh-my-posh`

Quite small and maybe useless, but compliant with other Homebrew formulas