### PR TITLE
feat: add support for `HOMEBREW_GOPROXY`

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -5,7 +5,7 @@ param (
     $Version
 )
 
-Invoke-Webrequest "https://github.com/JanDeDobbeleer/oh-my-posh3/archive/v$Version.tar.gz" -OutFile "v$Version.tar.gz"
+Invoke-Webrequest "https://github.com/JanDeDobbeleer/oh-my-posh/archive/v$Version.tar.gz" -OutFile "v$Version.tar.gz"
 $fileHash = Get-FileHash -Algorithm SHA256 -Path "v$Version.tar.gz"
 $hash = $fileHash.Hash.ToLower()
 Remove-Item -Path "v$Version.tar.gz"

--- a/build/oh-my-posh.txt
+++ b/build/oh-my-posh.txt
@@ -11,6 +11,7 @@ class OhMyPosh < Formula
 
   def install
     Dir.chdir("src") do
+      ENV["GOPROXY"] = ENV.has_key?("HOMEBREW_GOPROXY") ? ENV["HOMEBREW_GOPROXY"] : ""
       system("go build -o=oh-my-posh -ldflags=\"-s -w -X \'main.Version=<VERSION>\'\"")
       bin.install "oh-my-posh"
     end

--- a/oh-my-posh.rb
+++ b/oh-my-posh.rb
@@ -6,11 +6,13 @@ class OhMyPosh < Formula
   sha256 "49ec9a365ebfa807451c2cde15c246ae9e1ba254a1ea1d64f19d452017a89289"
   license "MIT"
   version "7.64.1"
+  revision 1
 
   depends_on "go@1.18" => :build
 
   def install
     Dir.chdir("src") do
+      ENV["GOPROXY"] = ENV.has_key?("HOMEBREW_GOPROXY") ? ENV["HOMEBREW_GOPROXY"] : ""
       system("go build -o=oh-my-posh -ldflags=\"-s -w -X \'main.Version=7.64.1\'\"")
       bin.install "oh-my-posh"
     end
@@ -32,4 +34,3 @@ class OhMyPosh < Formula
     system "#{bin}/oh-my-posh", "--help"
   end
 end
-


### PR DESCRIPTION
Add a support of using user-defined `HOMEBREW_GOPROXY` env to make it friendly to users who don't have access to `proxy.golang.org`. Related: #4.