### PR TITLE
fix: disable VCS stamping during build to fix Go 1.18+ build error

### DIFF
--- a/build/formula.rb
+++ b/build/formula.rb
@@ -12,7 +12,7 @@ class OhMyPosh < Formula
   def install
     Dir.chdir("src") do
       ENV["GOPROXY"] = ENV.has_key?("HOMEBREW_GOPROXY") ? ENV["HOMEBREW_GOPROXY"] : ""
-      system("go build -o=oh-my-posh -ldflags=\"-s -w -X \'github.com/jandedobbeleer/oh-my-posh/src/build.Version=<VERSION>\' -X \'github.com/jandedobbeleer/oh-my-posh/src/build.Date=<DATE>\'\"")
+      system("go build -buildvcs=false -o=oh-my-posh -ldflags=\"-s -w -X 'github.com/jandedobbeleer/oh-my-posh/src/build.Version=<VERSION>' -X 'github.com/jandedobbeleer/oh-my-posh/src/build.Date=<DATE>'\"")
       bin.install "oh-my-posh"
     end
     mv "themes", prefix

--- a/oh-my-posh.rb
+++ b/oh-my-posh.rb
@@ -12,7 +12,7 @@ class OhMyPosh < Formula
   def install
     Dir.chdir("src") do
       ENV["GOPROXY"] = ENV.has_key?("HOMEBREW_GOPROXY") ? ENV["HOMEBREW_GOPROXY"] : ""
-      system("go build -o=oh-my-posh -ldflags=\"-s -w -X \'github.com/jandedobbeleer/oh-my-posh/src/build.Version=25.23.2\' -X \'github.com/jandedobbeleer/oh-my-posh/src/build.Date=2025-05-21T09:53:15Z\'\"")
+      system("go build -buildvcs=false -o=oh-my-posh -ldflags=\"-s -w -X \'github.com/jandedobbeleer/oh-my-posh/src/build.Version=25.23.2\' -X \'github.com/jandedobbeleer/oh-my-posh/src/build.Date=2025-05-21T09:53:15Z\'\"")
       bin.install "oh-my-posh"
     end
     mv "themes", prefix


### PR DESCRIPTION
This PR fixes the build failure encountered when installing Oh My Posh from source using Go 1.18 and newer.

Refs JanDeDobbeleer/oh-my-posh#6449

## Background

Starting with Go 1.18, the compiler enables version control system (VCS) stamping by default during builds. When building from a source tarball that lacks the `.git` directory (as done by the Homebrew formula), this results in the error:

```
error obtaining VCS status: exit status 128
Use -buildvcs=false to disable VCS stamping.
```

## Changes Made

* Added the build flag `-buildvcs=false` to the `go build` command in:

  * The root `oh-my-posh.rb` formula, fixing immediate installation issues for end users.
  * The `build/formula.rb` template used by the GitHub Action workflow, so all future formula versions generated via CI/CD will include the fix automatically.

## Impact

* Current users installing from source or via Homebrew on Linux and other environments will no longer encounter the build error.
* Formula updates triggered by the GitHub Action will remain consistent and error-free moving forward.

## Testing & Verification

* Local build testing recommended to ensure the updated formula builds successfully.
* The GitHub Action workflow should be tested by triggering a dry-run release with this updated formula template.