### PR TITLE
Update Go dependency to latest version

### DIFF
--- a/oh-my-posh.rb
+++ b/oh-my-posh.rb
@@ -7,7 +7,7 @@ class OhMyPosh < Formula
   license "MIT"
   version "29.3.0"
 
-  depends_on "go@1.25" => :build
+  depends_on "go" => :build
 
   def install
     Dir.chdir("src") do


### PR DESCRIPTION
This pull request makes a minor update to the build dependencies for the `OhMyPosh` formula. The dependency on a specific Go version has been relaxed to allow any available version of Go to be used for building.

* Changed the build dependency from `go@1.25` to the more general `go`, allowing the formula to build with any version of Go installed.

See https://github.com/JanDeDobbeleer/homebrew-oh-my-posh/issues/43