### PR TITLE
fix: wrap macOS-only cask stanzas in on_macos (Linux/WSL load error)

### DIFF
--- a/Casks/oh-my-posh.rb
+++ b/Casks/oh-my-posh.rb
@@ -1,14 +1,17 @@
 cask "oh-my-posh" do
     desc "Prompt theme engine for any shell"
     homepage "https://ohmyposh.dev"
-    arch arm: "arm64", intel: "amd64"
     version "29.19.0"
-    url "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v#{version}/posh-darwin-#{arch}",
-        verified: "github.com/JanDeDobbeleer/oh-my-posh/"
-    sha256 arm:   "23cb0817c60296ab64ec8fc4be43ffdfca7405ef9e0b1e076149ba5413fb08ac",
-           intel: "d94b878ac059f16acbb9aff2056b3d37c6d513a8eca1e803aaaaeb4d202c0036"
     name "oh-my-posh"
-    binary "posh-darwin-#{arch}", target: "oh-my-posh"
+
+    on_macos do
+        arch arm: "arm64", intel: "amd64"
+        url "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v#{version}/posh-darwin-#{arch}",
+            verified: "github.com/JanDeDobbeleer/oh-my-posh/"
+        sha256 arm:   "23cb0817c60296ab64ec8fc4be43ffdfca7405ef9e0b1e076149ba5413fb08ac",
+               intel: "d94b878ac059f16acbb9aff2056b3d37c6d513a8eca1e803aaaaeb4d202c0036"
+        binary "posh-darwin-#{arch}", target: "oh-my-posh"
+    end
+
     auto_updates true
 end
-

--- a/build/cask.rb
+++ b/build/cask.rb
@@ -1,13 +1,17 @@
 cask "oh-my-posh" do
     desc "Prompt theme engine for any shell"
     homepage "https://ohmyposh.dev"
-    arch arm: "arm64", intel: "amd64"
     version "<VERSION>"
-    url "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v#{version}/posh-darwin-#{arch}",
-        verified: "github.com/JanDeDobbeleer/oh-my-posh/"
-    sha256 arm:   "<SHA256-ARM>",
-           intel: "<SHA256-INTEL>"
     name "oh-my-posh"
-    binary "posh-darwin-#{arch}", target: "oh-my-posh"
+
+    on_macos do
+        arch arm: "arm64", intel: "amd64"
+        url "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v#{version}/posh-darwin-#{arch}",
+            verified: "github.com/JanDeDobbeleer/oh-my-posh/"
+        sha256 arm:   "<SHA256-ARM>",
+               intel: "<SHA256-INTEL>"
+        binary "posh-darwin-#{arch}", target: "oh-my-posh"
+    end
+
     auto_updates true
 end


### PR DESCRIPTION
## What

Wrap the macOS-only stanzas (`arch`, `url`, `sha256`, `binary`) of the `oh-my-posh` cask in an `on_macos do … end` block, in both the generator template (`build/cask.rb`) and the generated `Casks/oh-my-posh.rb`.

## Why

Recent Homebrew versions eagerly **load and validate cask definitions on Linux** (at `tap`/`update`/`install`/`uninstall`). Our cask only defines macOS `sha256 arm:`/`intel:` values; on Linux the checksum resolves through the `linux:` branch of `on_system_conditional` (`x86_64_linux`/`arm64_linux`), which is unset, so it becomes `nil` and Homebrew aborts with:

    Error: Cask 'oh-my-posh' definition is invalid: invalid 'sha256' value: nil

This exits non-zero (breaking `brew update`/`upgrade` in scripts) and even blocks `brew uninstall`/`brew untap`, leaving Linux/WSL users stuck. Linux users are served by the **formula**, not this cask.

Wrapping the macOS-only stanzas in `on_macos` makes Homebrew skip them on Linux (the block body only runs on macOS), so the cask loads cleanly everywhere. macOS install behavior is unchanged.

Same root cause and fix as hashicorp/homebrew-tap#354; see Homebrew discussion #6008.

## Notes

- `build/cask.rb` is the template that `build/build.ps1` fills on each release, so it must change too or the fix would be reverted on the next version bump.
- No Linux `sha256` is added — the cask intentionally has no Linux artifact.

Fixes JanDeDobbeleer/oh-my-posh#7580
